### PR TITLE
Replace deprecated SFC syntax with FunctionComponent

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-const Hello: React.SFC<{ compiler: string, framework: string }> = (props) => {
+const Hello: React.FunctionComponent<{ compiler: string, framework: string }> = (props) => {
   return (
     <div>
       <div>{props.compiler}</div>


### PR DESCRIPTION
visit https://github.com/DefinitelyTyped/DefinitelyTyped/pull/30364
This PR renames React.SFC and React.StatelessComponent to
React.FunctionComponent, while introducing deprecated aliases
for the old names.