### PR TITLE
Configure dev server to send all requests to /index

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,5 +22,8 @@ module.exports = {
     rules: [
       { test: /\.tsx?$/, loader: 'ts-loader' }
     ]
+  },
+  devServer: {
+    historyApiFallback: true,
   }
 }


### PR DESCRIPTION
While webpack-dev-server was only listening for the root route. This changes it to listen on all routes so we can do client side routing